### PR TITLE
fix: 让用户可以覆盖 Python 下载源 (#14)

### DIFF
--- a/.github/workflows/sync_python.yml
+++ b/.github/workflows/sync_python.yml
@@ -86,6 +86,15 @@ jobs:
             --manifest-output "$stage_dir/python-assets.json" \
             --public-base-url "$PUBLIC_BASE_URL"
 
+          # Same entry set, but with upstream URLs left intact so uv accepts
+          # UV_PYTHON_INSTALL_MIRROR. Served alongside the rewritten variant so
+          # existing installs keep resolving the old endpoint unchanged.
+          python3 -m scripts.mirrorctl build-python-downloads \
+            --input "$stage_dir/upstream-download-metadata.json" \
+            --output "$stage_dir/metadata/python-downloads-upstream.json" \
+            --public-base-url "$PUBLIC_BASE_URL" \
+            --keep-upstream-urls
+
           python3 -m scripts.mirrorctl download-python-assets \
             --manifest "$stage_dir/python-assets.json" \
             --stage-dir "$stage_dir"
@@ -117,4 +126,9 @@ jobs:
           python3 -m scripts.mirrorctl upload-file \
             --local-path "$stage_dir/metadata/python-downloads.json" \
             --key "$(with_prefix "metadata/python-downloads.json")" \
+            --cache-control "public, max-age=300"
+
+          python3 -m scripts.mirrorctl upload-file \
+            --local-path "$stage_dir/metadata/python-downloads-upstream.json" \
+            --key "$(with_prefix "metadata/python-downloads-upstream.json")" \
             --cache-control "public, max-age=300"

--- a/README.md
+++ b/README.md
@@ -53,9 +53,15 @@ powershell -ExecutionPolicy ByPass -c "irm https://uv.agentsmirror.com/install-c
 当前会自动写入这些配置：
 
 - `python-downloads-json-url`
+- `python-install-mirror`
+- `pypy-install-mirror`
 - `UV_INSTALLER_GITHUB_BASE_URL`
 - `UV_PYTHON_DOWNLOADS_JSON_URL`
+- `UV_PYTHON_INSTALL_MIRROR`
+- `UV_PYPY_INSTALL_MIRROR`
 - `UV_DEFAULT_INDEX`
+
+受管块里的每个环境变量都是**默认值**而非强制值：如果你在此之前已经导出过同名变量，镜像会让位给你的设置，不需要删除 `uv.toml` 或受管块。
 
 其中 `UV_DEFAULT_INDEX` 现在默认写入：
 
@@ -71,9 +77,27 @@ https://uv.agentsmirror.com/pypi/simple
 
 如果本机已经存在 `uv.toml`，脚本会先备份，再只更新受管键。
 
-PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 installer 会清理历史安装留下的 `pypy-install-mirror` 与 `UV_PYPY_INSTALL_MIRROR`。
+PyPy 下载地址由 `metadata/python-downloads-upstream.json` 统一提供。
 
 为了让后续 `uv self update` 继续走镜像，profile 中还会写入一段受管块；如果你不想保留镜像环境变量，可以在安装后手动删除。
+
+## 换用第三方 Python 下载源
+
+如果你希望 `uv python install` 走别的源（例如高校镜像），直接导出 `UV_PYTHON_INSTALL_MIRROR` 即可，**不需要删除 `uv.toml` 或受管块**：
+
+```bash
+export UV_PYTHON_INSTALL_MIRROR="https://mirror.nju.edu.cn/github-release/astral-sh/python-build-standalone"
+uv python install 3.12.13
+```
+
+这一点依赖 `UV_PYTHON_DOWNLOADS_JSON_URL` 指向 `metadata/python-downloads-upstream.json`——该端点保留上游 GitHub 原始下载地址。uv 只有在能剥离官方前缀时才接受 `UV_PYTHON_INSTALL_MIRROR`，因此改写过 URL 的 `metadata/python-downloads.json` 会让它直接报错：
+
+```text
+A mirror was provided via `UV_PYTHON_INSTALL_MIRROR`,
+but the URL does not match the expected format
+```
+
+两个端点会同时提供，`metadata/python-downloads.json` 保留改写后的地址以兼容既有安装。
 
 ## 恢复官方设置 / 退出镜像
 
@@ -108,8 +132,8 @@ PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 inst
 当前需要移除的是：
 
 - `python-downloads-json-url`
-
-历史安装还可能带有 `pypy-install-mirror`，一起删除即可。
+- `python-install-mirror`
+- `pypy-install-mirror`
 
 如果你希望最稳妥地恢复到安装前状态，优先建议直接用安装时生成的备份文件覆盖当前 `uv.toml`。
 
@@ -119,9 +143,9 @@ PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 inst
 
 - `UV_INSTALLER_GITHUB_BASE_URL`
 - `UV_PYTHON_DOWNLOADS_JSON_URL`
+- `UV_PYTHON_INSTALL_MIRROR`
+- `UV_PYPY_INSTALL_MIRROR`
 - `UV_DEFAULT_INDEX`
-
-历史安装还可能带有 `UV_PYPY_INSTALL_MIRROR`，一起删除即可。
 
 完成以上步骤后，后续 `uv self update`、`uv python install`、`uv add`、`uv sync`、`uv pip install` 等行为，就会重新回到官方默认链路。
 
@@ -157,6 +181,7 @@ PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 inst
   - `/install-cn.ps1`
   - `/metadata/uv-latest.json`
   - `/metadata/python-downloads.json`
+  - `/metadata/python-downloads-upstream.json`
 
 ## 镜像路径约定
 
@@ -169,6 +194,7 @@ PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 inst
 /graalpython/releases/download/<build>/...
 /metadata/uv-latest.json
 /metadata/python-downloads.json
+/metadata/python-downloads-upstream.json
 /pypi/simple/<project>/
 /pypi/files/files.pythonhosted.org/...
 /install-cn.sh
@@ -191,12 +217,13 @@ PyPy 下载地址由 `metadata/python-downloads.json` 统一提供。重跑 inst
 
 - 每 6 小时拉取一次上游 `download-metadata.json`
 - 对 `CPython`、`PyPy`、`GraalPy` 各自只保留最新 build
-- 重写下载地址到公开镜像域名
+- 生成两份元数据：改写到镜像域名的 `python-downloads.json`，以及保留上游地址的 `python-downloads-upstream.json`
 - 上传并清理：
   - `/python-build-standalone/...`
   - `/pypy/...`
   - `/graalpython/...`
   - `/metadata/python-downloads.json`
+  - `/metadata/python-downloads-upstream.json`
 
 ## 默认 PyPI
 

--- a/cloudflare/uv-origin-proxy/src/index.js
+++ b/cloudflare/uv-origin-proxy/src/index.js
@@ -11,6 +11,16 @@ const REQUIRED_ENV_KEYS = [
 ];
 const DEFAULT_PRESIGN_TTL_SECONDS = 600;
 const PROXIED_SUFFIXES = [".json", ".ps1", ".sh"];
+// Object keys for Python runtimes are sanitized at sync time (see
+// `uvmirror.metadata.mirror_path_for_python_download_url`), so `+` and `%` in the
+// upstream filename become `-plus-` / `-pct-`. uv builds its own download URL by
+// appending the upstream suffix to `UV_PYTHON_INSTALL_MIRROR`, which keeps the raw
+// `+`. Normalizing here lets both spellings resolve to the same object.
+const PYTHON_ASSET_PREFIXES = [
+  "/python-build-standalone/releases/download/",
+  "/pypy/",
+  "/graalpython/releases/download/",
+];
 const textEncoder = new TextEncoder();
 
 export default {
@@ -51,6 +61,8 @@ export default {
     if (isPypiFileRequest(requestUrl.pathname)) {
       return proxyPypiFile(request, requestUrl, env);
     }
+
+    normalizePythonAssetPath(requestUrl);
 
     const signedUrl = await buildPresignedUrl(
       request.method,
@@ -438,6 +450,38 @@ function isResponseFresh(response, maxAgeSeconds) {
 
 function shouldProxyThroughWorker(pathname) {
   return PROXIED_SUFFIXES.some((suffix) => pathname.endsWith(suffix));
+}
+
+function isPythonAssetRequest(pathname) {
+  return PYTHON_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+function sanitizePythonAssetSegment(segment) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    // Leave malformed percent-escapes untouched; the origin decides the outcome.
+    return segment;
+  }
+  return decoded.replace(/%/g, "-pct-").replace(/\+/g, "-plus-");
+}
+
+/**
+ * Rewrite a Python runtime request in place so the raw upstream filename and the
+ * sanitized object key both resolve. Already-sanitized paths contain no `+` or `%`,
+ * so this is a no-op for them and stays idempotent.
+ */
+function normalizePythonAssetPath(requestUrl) {
+  if (!isPythonAssetRequest(requestUrl.pathname)) {
+    return requestUrl;
+  }
+
+  requestUrl.pathname = requestUrl.pathname
+    .split("/")
+    .map((segment) => sanitizePythonAssetSegment(segment))
+    .join("/");
+  return requestUrl;
 }
 
 function buildOriginUrl(originEndpoint, bucket, requestUrl, keyPrefix = "") {

--- a/cloudflare/uv-origin-proxy/test/index.test.js
+++ b/cloudflare/uv-origin-proxy/test/index.test.js
@@ -715,3 +715,66 @@ test("handles head requests for pypi simple json without reading a body", async 
   assert.equal(await response.text(), "");
   assert.equal(fetchCalls[1].method, "HEAD");
 });
+
+const PBS_BASE =
+  "https://uv.agentsmirror.com/python-build-standalone/releases/download/20260718";
+const SANITIZED_KEY =
+  "/20830-uv-custom/python-build-standalone/releases/download/20260718/cpython-3.12.13-plus-20260718-aarch64-apple-darwin-install_only_stripped.tar.gz";
+
+async function signedPathnameFor(url) {
+  const response = await worker.fetch(new Request(url), ENV);
+  assert.equal(response.status, 307);
+  return new URL(response.headers.get("location")).pathname;
+}
+
+test("resolves python assets whose filename keeps the upstream plus sign", async () => {
+  // This is the URL uv builds when UV_PYTHON_INSTALL_MIRROR points at the mirror.
+  const pathname = await signedPathnameFor(
+    `${PBS_BASE}/cpython-3.12.13+20260718-aarch64-apple-darwin-install_only_stripped.tar.gz`,
+  );
+
+  assert.equal(pathname, SANITIZED_KEY);
+});
+
+test("resolves python assets whose plus sign is percent-encoded", async () => {
+  const pathname = await signedPathnameFor(
+    `${PBS_BASE}/cpython-3.12.13%2B20260718-aarch64-apple-darwin-install_only_stripped.tar.gz`,
+  );
+
+  assert.equal(pathname, SANITIZED_KEY);
+});
+
+test("leaves already sanitized python asset keys untouched", async () => {
+  const pathname = await signedPathnameFor(
+    `${PBS_BASE}/cpython-3.12.13-plus-20260718-aarch64-apple-darwin-install_only_stripped.tar.gz`,
+  );
+
+  assert.equal(pathname, SANITIZED_KEY);
+});
+
+test("sanitizes pypy and graalpy asset paths as well", async () => {
+  assert.equal(
+    await signedPathnameFor(
+      "https://uv.agentsmirror.com/pypy/pypy3.11-v7.3.20+src-linux64.tar.bz2",
+    ),
+    "/20830-uv-custom/pypy/pypy3.11-v7.3.20-plus-src-linux64.tar.bz2",
+  );
+
+  assert.equal(
+    await signedPathnameFor(
+      "https://uv.agentsmirror.com/graalpython/releases/download/24.1/graalpy-24.1+1-linux.tar.gz",
+    ),
+    "/20830-uv-custom/graalpython/releases/download/24.1/graalpy-24.1-plus-1-linux.tar.gz",
+  );
+});
+
+test("does not rewrite plus signs outside python asset paths", async () => {
+  const pathname = await signedPathnameFor(
+    "https://uv.agentsmirror.com/github/astral-sh/uv/releases/download/latest/uv+installer.sh.gz",
+  );
+
+  assert.equal(
+    pathname,
+    "/20830-uv-custom/github/astral-sh/uv/releases/download/latest/uv+installer.sh.gz",
+  );
+});

--- a/scripts/mirrorctl.py
+++ b/scripts/mirrorctl.py
@@ -23,6 +23,7 @@ def build_python_downloads(
     output_path: pathlib.Path,
     public_base_url: str,
     manifest_output: pathlib.Path | None,
+    keep_upstream_urls: bool = False,
 ) -> None:
     raw_metadata = json.loads(input_path.read_text(encoding="utf-8"))
     selected_entries = keep_latest_runtime_builds(raw_metadata.values())
@@ -32,7 +33,9 @@ def build_python_downloads(
     trimmed = {
         key: value for key, value in raw_metadata.items() if key in selected_keys
     }
-    rewritten = build_rewritten_python_metadata(trimmed, public_base_url)
+    rewritten = build_rewritten_python_metadata(
+        trimmed, public_base_url, keep_upstream_urls=keep_upstream_urls
+    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
         json.dumps(rewritten, indent=2, sort_keys=True) + "\n",
@@ -136,6 +139,14 @@ def main() -> None:
     python_downloads.add_argument("--output", type=pathlib.Path, required=True)
     python_downloads.add_argument("--public-base-url", required=True)
     python_downloads.add_argument("--manifest-output", type=pathlib.Path)
+    python_downloads.add_argument(
+        "--keep-upstream-urls",
+        action="store_true",
+        help=(
+            "Keep upstream download URLs verbatim so UV_PYTHON_INSTALL_MIRROR "
+            "stays usable and overridable."
+        ),
+    )
 
     download_python_assets_parser = subparsers.add_parser("download-python-assets")
     download_python_assets_parser.add_argument("--manifest", type=pathlib.Path, required=True)
@@ -179,6 +190,7 @@ def main() -> None:
             args.output,
             args.public_base_url,
             args.manifest_output,
+            keep_upstream_urls=args.keep_upstream_urls,
         )
         return
 

--- a/tests/test_uvmirror.py
+++ b/tests/test_uvmirror.py
@@ -8,6 +8,7 @@ import urllib.error
 from uvmirror.downloads import download_python_assets
 from uvmirror.installers import render_installers
 from uvmirror.metadata import (
+    build_rewritten_python_metadata,
     build_state_manifest,
     diff_stale_keys,
     keep_latest_runtime_builds,
@@ -202,6 +203,30 @@ class MetadataTests(unittest.TestCase):
             "graalpython/releases/download/graal-25.0.2/graalpy.tar.gz",
         )
 
+    def test_build_rewritten_python_metadata_can_keep_upstream_urls(self) -> None:
+        upstream_url = (
+            "https://github.com/astral-sh/python-build-standalone/releases/download/"
+            "20260718/cpython-3.12.13%2B20260718-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        )
+        raw = {"cpython-3.12.13-darwin-aarch64-none": {"url": upstream_url, "name": "cpython"}}
+
+        rewritten = build_rewritten_python_metadata(raw, "https://uv.example.com")
+        self.assertEqual(
+            rewritten["cpython-3.12.13-darwin-aarch64-none"]["url"],
+            "https://uv.example.com/python-build-standalone/releases/download/20260718/"
+            "cpython-3.12.13-plus-20260718-aarch64-apple-darwin-install_only_stripped.tar.gz",
+        )
+
+        # uv only accepts UV_PYTHON_INSTALL_MIRROR when the entry still carries the
+        # canonical upstream prefix, so this variant must be left untouched.
+        kept = build_rewritten_python_metadata(
+            raw, "https://uv.example.com", keep_upstream_urls=True
+        )
+        self.assertEqual(
+            kept["cpython-3.12.13-darwin-aarch64-none"]["url"], upstream_url
+        )
+        self.assertEqual(kept["cpython-3.12.13-darwin-aarch64-none"]["name"], "cpython")
+
 
 class ReleaseTests(unittest.TestCase):
     def test_prune_uv_tags_keeps_latest_n(self) -> None:
@@ -234,11 +259,11 @@ class InstallerTests(unittest.TestCase):
         )
         self.assertIn('printf \'%s\\n\' "$line"', rendered.shell)
         self.assertIn(
-            'python-downloads-json-url = "%s/metadata/python-downloads.json"\\n',
+            'python-downloads-json-url = "%s/metadata/python-downloads-upstream.json"\\n',
             rendered.shell,
         )
         self.assertIn(
-            'python-downloads-json-url\\ =*|pypy-install-mirror\\ =*)',
+            'python-downloads-json-url\\ =*|python-install-mirror\\ =*|pypy-install-mirror\\ =*)',
             rendered.shell,
         )
         self.assertNotIn(
@@ -246,8 +271,6 @@ class InstallerTests(unittest.TestCase):
             rendered.shell,
         )
         self.assertNotIn("printf '%s\n' \"$line\"", rendered.shell)
-        self.assertNotIn("UV_PYPY_INSTALL_MIRROR", rendered.shell)
-        self.assertNotIn('pypy-install-mirror = "%s/pypy"\\n', rendered.shell)
         self.assertIn("https://uv.example.com/github", rendered.powershell)
         self.assertIn("https://pypi.tuna.tsinghua.edu.cn/simple", rendered.powershell)
         self.assertIn(
@@ -255,18 +278,17 @@ class InstallerTests(unittest.TestCase):
             rendered.powershell,
         )
         self.assertIn(
-            '$env:UV_PYTHON_DOWNLOADS_JSON_URL = "$PublicBaseUrl/metadata/python-downloads.json"',
+            '$env:UV_PYTHON_DOWNLOADS_JSON_URL = "$PublicBaseUrl/metadata/python-downloads-upstream.json"',
             rendered.powershell,
         )
-        self.assertNotIn("UV_PYTHON_INSTALL_MIRROR", rendered.shell)
-        self.assertNotIn('python-install-mirror = "', rendered.shell)
-        self.assertNotIn("UV_PYTHON_INSTALL_MIRROR", rendered.powershell)
+        self.assertIn(
+            'if ($Line.Trim().StartsWith("python-install-mirror =")) { continue }',
+            rendered.powershell,
+        )
         self.assertIn(
             'if ($Line.Trim().StartsWith("pypy-install-mirror =")) { continue }',
             rendered.powershell,
         )
-        self.assertNotIn("UV_PYPY_INSTALL_MIRROR", rendered.powershell)
-        self.assertNotIn('pypy-install-mirror = "', rendered.powershell)
         self.assertLess(
             rendered.powershell.index(
                 '$env:UV_INSTALLER_GITHUB_BASE_URL = "$PublicBaseUrl/github"'
@@ -274,6 +296,50 @@ class InstallerTests(unittest.TestCase):
             rendered.powershell.index(
                 'irm "$PublicBaseUrl/github/astral-sh/uv/releases/download/latest/uv-installer.ps1" | iex'
             ),
+        )
+
+    def test_render_installers_ships_overridable_python_install_mirrors(self) -> None:
+        """The upstream-URL metadata endpoint makes UV_PYTHON_INSTALL_MIRROR usable again.
+
+        It was dropped in 9a4ebd8 because rewritten URLs made uv fail with
+        ``Error::Mirror``; serving upstream URLs removes that conflict.
+        """
+        rendered = render_installers(
+            public_base_url="https://uv.example.com",
+            default_index_url="https://pypi.tuna.tsinghua.edu.cn/simple",
+        )
+
+        # Defaults are only applied when the user has not set their own value.
+        self.assertIn(
+            'export UV_PYTHON_INSTALL_MIRROR="${UV_PYTHON_INSTALL_MIRROR:-'
+            'https://uv.example.com/python-build-standalone/releases/download}"',
+            rendered.shell,
+        )
+        self.assertIn(
+            'export UV_PYPY_INSTALL_MIRROR="${UV_PYPY_INSTALL_MIRROR:-'
+            'https://uv.example.com/pypy}"',
+            rendered.shell,
+        )
+        self.assertIn(
+            'export UV_PYTHON_DOWNLOADS_JSON_URL="${UV_PYTHON_DOWNLOADS_JSON_URL:-'
+            'https://uv.example.com/metadata/python-downloads-upstream.json}"',
+            rendered.shell,
+        )
+        self.assertIn(
+            'python-install-mirror = "%s/python-build-standalone/releases/download"\\n',
+            rendered.shell,
+        )
+        self.assertIn('pypy-install-mirror = "%s/pypy"\\n', rendered.shell)
+
+        self.assertIn(
+            'if (-not $env:UV_PYTHON_INSTALL_MIRROR) { $env:UV_PYTHON_INSTALL_MIRROR = '
+            '"https://uv.example.com/python-build-standalone/releases/download" }',
+            rendered.powershell,
+        )
+        self.assertIn(
+            'if (-not $env:UV_PYPY_INSTALL_MIRROR) { $env:UV_PYPY_INSTALL_MIRROR = '
+            '"https://uv.example.com/pypy" }',
+            rendered.powershell,
         )
 
     def test_render_installers_powershell_guards_against_empty_profile_content(self) -> None:

--- a/uvmirror/installers.py
+++ b/uvmirror/installers.py
@@ -12,9 +12,13 @@ append_managed_block() {
   target_file="$1"
   managed_block=$(cat <<'EOF'
 # >>> uv mirror managed block >>>
-export UV_INSTALLER_GITHUB_BASE_URL="__PUBLIC_BASE_URL__/github"
-export UV_PYTHON_DOWNLOADS_JSON_URL="__PUBLIC_BASE_URL__/metadata/python-downloads.json"
-export UV_DEFAULT_INDEX="__DEFAULT_INDEX_URL__"
+# Every value below is a default: export your own before this block (or in a later
+# profile line) and the mirror will step aside instead of overriding you.
+export UV_INSTALLER_GITHUB_BASE_URL="${UV_INSTALLER_GITHUB_BASE_URL:-__PUBLIC_BASE_URL__/github}"
+export UV_PYTHON_DOWNLOADS_JSON_URL="${UV_PYTHON_DOWNLOADS_JSON_URL:-__PUBLIC_BASE_URL__/metadata/python-downloads-upstream.json}"
+export UV_PYTHON_INSTALL_MIRROR="${UV_PYTHON_INSTALL_MIRROR:-__PUBLIC_BASE_URL__/python-build-standalone/releases/download}"
+export UV_PYPY_INSTALL_MIRROR="${UV_PYPY_INSTALL_MIRROR:-__PUBLIC_BASE_URL__/pypy}"
+export UV_DEFAULT_INDEX="${UV_DEFAULT_INDEX:-__DEFAULT_INDEX_URL__}"
 # <<< uv mirror managed block <<<
 EOF
 )
@@ -47,7 +51,7 @@ write_uv_config() {
     while IFS= read -r line || [ -n "$line" ]; do
       trimmed=$(printf '%s' "$line" | sed 's/^[[:space:]]*//')
       case "$trimmed" in
-        python-downloads-json-url\\ =*|pypy-install-mirror\\ =*)
+        python-downloads-json-url\\ =*|python-install-mirror\\ =*|pypy-install-mirror\\ =*)
           continue
           ;;
       esac
@@ -59,7 +63,12 @@ write_uv_config() {
     printf '\\n' >> "$tmp_file"
   fi
 
-  printf 'python-downloads-json-url = "%s/metadata/python-downloads.json"\\n' "$PUBLIC_BASE_URL" >> "$tmp_file"
+  # Mirror the managed block so non-login shells (which never source the profile)
+  # still resolve through the mirror. Environment variables outrank uv.toml, so an
+  # explicit UV_PYTHON_INSTALL_MIRROR still wins over these defaults.
+  printf 'python-downloads-json-url = "%s/metadata/python-downloads-upstream.json"\\n' "$PUBLIC_BASE_URL" >> "$tmp_file"
+  printf 'python-install-mirror = "%s/python-build-standalone/releases/download"\\n' "$PUBLIC_BASE_URL" >> "$tmp_file"
+  printf 'pypy-install-mirror = "%s/pypy"\\n' "$PUBLIC_BASE_URL" >> "$tmp_file"
   mv "$tmp_file" "$config_file"
 }
 
@@ -95,9 +104,12 @@ function Set-ManagedBlock {
 
     $ManagedBlock = @'
 # >>> uv mirror managed block >>>
-$env:UV_INSTALLER_GITHUB_BASE_URL = "__PUBLIC_BASE_URL__/github"
-$env:UV_PYTHON_DOWNLOADS_JSON_URL = "__PUBLIC_BASE_URL__/metadata/python-downloads.json"
-$env:UV_DEFAULT_INDEX = "__DEFAULT_INDEX_URL__"
+# Every value below is a default: set your own beforehand and the mirror steps aside.
+if (-not $env:UV_INSTALLER_GITHUB_BASE_URL) { $env:UV_INSTALLER_GITHUB_BASE_URL = "__PUBLIC_BASE_URL__/github" }
+if (-not $env:UV_PYTHON_DOWNLOADS_JSON_URL) { $env:UV_PYTHON_DOWNLOADS_JSON_URL = "__PUBLIC_BASE_URL__/metadata/python-downloads-upstream.json" }
+if (-not $env:UV_PYTHON_INSTALL_MIRROR) { $env:UV_PYTHON_INSTALL_MIRROR = "__PUBLIC_BASE_URL__/python-build-standalone/releases/download" }
+if (-not $env:UV_PYPY_INSTALL_MIRROR) { $env:UV_PYPY_INSTALL_MIRROR = "__PUBLIC_BASE_URL__/pypy" }
+if (-not $env:UV_DEFAULT_INDEX) { $env:UV_DEFAULT_INDEX = "__DEFAULT_INDEX_URL__" }
 # <<< uv mirror managed block <<<
 '@
 
@@ -144,6 +156,7 @@ function Set-UvConfig {
     $Lines = @()
     foreach ($Line in $Existing -split "\r?\n") {
         if ($Line.Trim().StartsWith("python-downloads-json-url =")) { continue }
+        if ($Line.Trim().StartsWith("python-install-mirror =")) { continue }
         if ($Line.Trim().StartsWith("pypy-install-mirror =")) { continue }
         $Lines += $Line
     }
@@ -160,12 +173,16 @@ function Set-UvConfig {
         $Lines += ""
     }
 
-    $Lines += 'python-downloads-json-url = "' + $PublicBaseUrl + '/metadata/python-downloads.json"'
+    $Lines += 'python-downloads-json-url = "' + $PublicBaseUrl + '/metadata/python-downloads-upstream.json"'
+    $Lines += 'python-install-mirror = "' + $PublicBaseUrl + '/python-build-standalone/releases/download"'
+    $Lines += 'pypy-install-mirror = "' + $PublicBaseUrl + '/pypy"'
     [System.IO.File]::WriteAllText($ConfigFile, ($Lines -join "`r`n") + "`r`n", [System.Text.UTF8Encoding]::new($false))
 }
 
 $env:UV_INSTALLER_GITHUB_BASE_URL = "$PublicBaseUrl/github"
-$env:UV_PYTHON_DOWNLOADS_JSON_URL = "$PublicBaseUrl/metadata/python-downloads.json"
+$env:UV_PYTHON_DOWNLOADS_JSON_URL = "$PublicBaseUrl/metadata/python-downloads-upstream.json"
+$env:UV_PYTHON_INSTALL_MIRROR = "$PublicBaseUrl/python-build-standalone/releases/download"
+$env:UV_PYPY_INSTALL_MIRROR = "$PublicBaseUrl/pypy"
 $env:UV_DEFAULT_INDEX = "__DEFAULT_INDEX_URL__"
 irm "$PublicBaseUrl/github/astral-sh/uv/releases/download/latest/uv-installer.ps1" | iex
 Set-UvConfig

--- a/uvmirror/metadata.py
+++ b/uvmirror/metadata.py
@@ -134,13 +134,23 @@ class RewrittenEntry:
 def build_rewritten_python_metadata(
     raw_metadata: dict[str, dict],
     public_base_url: str,
+    keep_upstream_urls: bool = False,
 ) -> dict[str, dict]:
+    """Build the ``python-downloads.json`` payload served to uv.
+
+    When ``keep_upstream_urls`` is set the upstream GitHub/python.org URLs are kept
+    verbatim. uv only honours ``UV_PYTHON_INSTALL_MIRROR`` when it can strip the
+    canonical upstream prefix off each entry, so rewriting the URLs here makes that
+    variable fail hard with ``Error::Mirror``. Keeping them lets callers point the
+    variable at this mirror by default and still override it with their own source.
+    """
     rewritten: dict[str, dict] = {}
     for key, entry in raw_metadata.items():
         rewritten_entry = dict(entry)
-        rewritten_entry["url"] = rewrite_python_download_url(
-            rewritten_entry["url"], public_base_url
-        )
+        if not keep_upstream_urls:
+            rewritten_entry["url"] = rewrite_python_download_url(
+                rewritten_entry["url"], public_base_url
+            )
         rewritten[key] = rewritten_entry
     return rewritten
 


### PR DESCRIPTION
## 问题

[#14](https://github.com/Wangnov/uv-custom/issues/14) 反馈：装了本项目之后，`UV_PYTHON_INSTALL_MIRROR` 失效，只能先删掉 `uv.toml` 才能用第三方 Python 源。

实测下来比"失效"更严重——是**硬报错**，直接装不上：

```console
$ UV_PYTHON_DOWNLOADS_JSON_URL="https://uv.agentsmirror.com/metadata/python-downloads.json" \
  UV_PYTHON_INSTALL_MIRROR="https://mirror.nju.edu.cn/github-release/astral-sh/python-build-standalone" \
  uv python install 3.12.13
error: Failed to install cpython-3.12.13-macos-aarch64-none
  Caused by: A mirror was provided via `UV_PYTHON_INSTALL_MIRROR`, but the URL does not match the expected format
```

而且 issue 里提到的绕法（删 `uv.toml`）现在也不管用了：受管块同时把 `UV_PYTHON_DOWNLOADS_JSON_URL` 写进了 `.zshrc` / `.bashrc` / `.profile`，删掉 `uv.toml` 环境变量还在。

## 根因

uv 侧的逻辑（`crates/uv-python/src/downloads.rs`）：

```rust
if let Some(mirror) = python_install_mirror {
    let Some(suffix) = self.url.strip_prefix(CPYTHON_DOWNLOADS_URL_PREFIX) else {
        return Err(Error::Mirror(...));   // 前缀对不上就直接报错
    };
```

`CPYTHON_DOWNLOADS_URL_PREFIX` 是 `https://github.com/astral-sh/python-build-standalone/releases/download/`。而我们的 `python-downloads.json` 里 342 个 URL 全部被改写成了 `https://uv.agentsmirror.com/...`，前缀剥不掉，于是必然走 `Error::Mirror`。

这正是 9a4ebd8（`fix: support uv python installs through the mirror`）当初不得不移除 `UV_PYTHON_INSTALL_MIRROR` 的原因——在"改写 URL"的架构下，两者天然互斥。那次移除在当时是对的，代价就是 #14。

## 方案

让两者不再互斥：**多提供一个保留上游 URL 的元数据端点**。

- `metadata/python-downloads.json` — 保持原样，改写后的镜像地址，既有安装不受任何影响
- `metadata/python-downloads-upstream.json` — 新增，URL 保持上游原始形态

安装脚本改为默认使用新端点，并配套导出 `UV_PYTHON_INSTALL_MIRROR` / `UV_PYPY_INSTALL_MIRROR` 指向本镜像。同时受管块里所有变量都改成 `${VAR:-default}` 形式（PowerShell 用 `if (-not $env:VAR)`），从"强制覆盖"变成"默认值"——用户自己导出过就让位，这正是 #14 想要的"不需要删配置"。

### Worker 侧的配套改动（必需）

对象存储里 Python 资产的 key 是 sanitize 过的（`+` → `-plus-`，见 `mirror_path_for_python_download_url`），而 uv 是拿上游后缀直接拼到 `UV_PYTHON_INSTALL_MIRROR` 后面，带的是原始 `+`。不处理的话默认路径会 404：

```console
Caused by: HTTP status client error (404 Not Found) for url (.../cpython-3.12.13%2B20260718-...tar.gz)
```

所以 Worker 增加了路径规范化，让 `+` / `%2B` / `%` 和已 sanitize 的两种写法都能命中同一个对象。已经是 `-plus-` 的路径不含 `+` 或 `%`，因此该转换幂等，对现有请求零影响。

## 验证

**修复后第三方源可用**（用 `--keep-upstream-urls` 生成的元数据 + 南大镜像，安装目录隔离）：

```console
$ UV_PYTHON_DOWNLOADS_JSON_URL="file:///tmp/pd-upstream.json" \
  UV_PYTHON_INSTALL_MIRROR="https://mirror.nju.edu.cn/github-release/astral-sh/python-build-standalone" \
  uv python install 3.12.13
Downloading cpython-3.12.13-macos-aarch64-none (download) (23.8MiB)
Installed Python 3.12.13 in 2.22s
```

**测试**：

- `python3 -m unittest tests.test_uvmirror tests.test_uv_smoke` → 27 passed
- `cd cloudflare/uv-origin-proxy && node --test` → 19 passed

新增用例覆盖：`keep_upstream_urls` 两种模式、受管块的可覆盖形式、Worker 对 `+` / `%2B` / 已 sanitize 三种路径的处理、以及 pypy/graalpy 路径和"不影响非 Python 路径"。

## 合并前需要确认

1. **Worker 需要重新部署**，否则新装用户的默认 Python 下载路径会 404（老用户不受影响，他们仍走改写端点）。建议顺序：先合并 → 部署 Worker → 跑一次 `sync_python.yml` 生成新端点 → 再验证 `install-cn.sh`。
2. 我无法在本地端到端验证 Worker 的线上行为，上面的 Worker 结论来自单元测试 + 对 S3 预签名路径的推导。
3. `sync_python.yml` 每次会多上传一个元数据文件，多一次 PUT。

## 顺带发现（未在本 PR 处理）

- 仓库有 27 个 Python 测试和 19 个 Worker 测试，但**没有任何 workflow 运行它们**——4 个 workflow 都是同步/部署用途。这些改动实际上没有 CI 兜底。
- README「当前状态」表里写的是 `uv python install 3.12.12`，镜像当前实际提供的是 `3.12.13`。
MSG
